### PR TITLE
fix unclosed link markup

### DIFF
--- a/docs/hub-validator/1-operate-validator/1-2-build-validator-node.md
+++ b/docs/hub-validator/1-operate-validator/1-2-build-validator-node.md
@@ -19,7 +19,7 @@ Validator node operation require stake from delgator or self delgation of **10,0
 
 - [x] 1.[**Check Hardware requirements**](/docs/hub-validator/operate-validator/1-1-hd-requirement) & [**validator account roles**](/docs/architecture/hub-layer/consensus/dpos/1-3-validator-account)
 - [x] 2.Install geth with [**Express setup**](/docs/hub-validator/operate-validator/1-2-build-validator-node#express-setup)[**Manual setup**](/docs/hub-validator/operate-validator/1-2-build-validator-node#manual-setup)
-- [x] 3.[**Join validator with PoS client**](/docs/hub-validator/operate-validator/1-3-join-validator#join-validator-to-pos-cli or [**Join validator with Web**](/docs/hub-validator/operate-validator/1-3-join-validator#join-validator-to-pos-web). Web is recommended.
+- [x] 3.[**Join validator with PoS client**](/docs/hub-validator/operate-validator/1-3-join-validator#join-validator-to-pos-cli) or [**Join validator with Web**](/docs/hub-validator/operate-validator/1-3-join-validator#join-validator-to-pos-web). Web is recommended.
 - [x] 4.[**stake your token with PoS client**](/docs/hub-validator/operate-validator/1-3-join-validator#4-staking) or [**stake your token with web**](/docs/hub-validator/operate-validator/1-3-join-validator#3-staking).
 - [x] 5.Check validation status on **next epoch**
 - [x] 6.After stable validation, run [**Instant verifier**](/docs/hub-validator/operate-validator/1-5-setup-verifier)


### PR DESCRIPTION
- Fix broken link mark up

## Ticket
https://www.notion.so/doublejumptokyo/link-not-work-in-doc-4ecf34a5807641ca82a3ca11aa46e875?pvs=4

## As Is
<img width="955" alt="スクリーンショット 2023-05-26 14 00 53" src="https://github.com/oasysgames/oasys-docs/assets/9178166/b65eeea8-d69f-4d25-a1e3-007ab303e44e">

## To Be
<img width="995" alt="スクリーンショット 2023-05-26 14 03 01" src="https://github.com/oasysgames/oasys-docs/assets/9178166/880f5050-faad-4dfb-be86-1145bf5b8b75">
