### PR TITLE
add setting file to skip 404 in direct access

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "cleanUrls": true
+}


### PR DESCRIPTION
## background
- algolia crawler accessed to 404 page that flashes when directly accessed to the page

### ref: https://vercel.com/docs/projects/project-configuration#cleanurls