### PR TITLE
modify upgrade l1 geth

### DIFF
--- a/docs/hub-validator/1-operate-validator/upgrade-migrate.md
+++ b/docs/hub-validator/1-operate-validator/upgrade-migrate.md
@@ -18,29 +18,20 @@ Secret key file Example:
 
 ### 3. Backing Up the Old Version of Geth
 To back up your old version of geth, follow these steps:
-```sh
-GETH_PATH=/usr/local/bin # Adjust this based on your environment
-VERSION=$($GETH_PATH/geth version | grep ...)
-mv $GETH_PATH/geth $GETH_PATH/geth-$VERSION
+```shell
+$ mv <DATA_DIR>/geth <DATA_DIR>/geth-backup # default DATA_DIR is /home/geth/.ethereum
+$ mv <INSTALL_PATH>/geth <INSTALL_PATH>/geth-backup # default INSTALL_PATH is /usr/local/bin/geth
 ```
 
-### 4. Downloading and Installing the Latest Version
-Download and unzip the latest version:
+### 4. Download the Latest Release
+Download from Oasys Validator GitHub [Releases](https://github.com/oasysgames/oasys-validator/releases). For setup details, consult the `setup.sh` code in the GitHub repository.
+You can learn how to use `setup.sh` at [Express setup](/docs/hub-validator/operate-validator/1-2-build-validator-node#express-setup).
+
 :::caution
 Ensure you download the **latest version** suitable for your CPU architecture:
 - For Intel or AMD CPUs: Download geth-version_number-linux-amd64.zip
 - For ARM-based CPUs: Download geth-version_number-linux-arm64.zip
 ::::::
-```sh
-wget https://github.com/oasysgames/oasys-validator/releases/download/<latest version>/geth-<latest version>-linux-<amd64|arm64>.zip
-unzip geth-<latest version>-linux-<amd64|arm64>.zip
-```
-
-Place the new version in the correct location and change its ownership:
-```sh
-sudo mv ./geth $GETH_PATH
-sudo chown geth:geth $GETH_PATH/geth
-```
 
 ### 5. Restart Geth
 Restart Geth with:


### PR DESCRIPTION
https://oasys-docs-git-feature-addupdategethversionv2-oasys.vercel.app/docs/hub-validator/operate-validator/upgrade-migrate#3-backing-up-the-old-version-of-geth
